### PR TITLE
Change grp-container from ID to class

### DIFF
--- a/polymorphic_tree/static/polymorphic_tree/adminlist/nodetree_grapelli.css
+++ b/polymorphic_tree/static/polymorphic_tree/adminlist/nodetree_grapelli.css
@@ -1,14 +1,14 @@
 /* grapelli styling and workarounds */
 
-#grp-container .results {
+.grp-container .results {
   margin: 0 0 5px 0;
 }
 
-#grp-container .jqtree-django table {
+.grp-container .jqtree-django table {
   width: 100%;  /* for grapelli */
 }
 
-#grp-container #js-result-list {
+.grp-container #js-result-list {
   border-left: 1px solid #ccc;
   border-bottom: 1px solid #ccc;
   border-right: 1px solid #ccc;
@@ -18,26 +18,26 @@
   margin-right: 1px;
 }
 
-#grp-container .jqtree-django ul.tree {
+.grp-container .jqtree-django ul.tree {
   margin: 0;
   padding: 0 0 0 12px;
   background-image: url(zebra-grapelli.png);
 }
 
-#grp-container .jqtree-django .col-primary,
-#grp-container .jqtree-django .col-metadata {
+.grp-container .jqtree-django .col-primary,
+.grp-container .jqtree-django .col-metadata {
   height: 36px;
 }
 
-#grp-container table thead th.col-title {
+.grp-container table thead th.col-title {
   border-top-left-radius: 2px;
   border-left: 0 none;
 }
 
-#grp-container .jqtree-django .col-metadata {
+.grp-container .jqtree-django .col-metadata {
   border-right: 0;
 }
 
-#grp-container .jqtree-django div.col {
+.grp-container .jqtree-django div.col {
   padding: 10px;
 }


### PR DESCRIPTION
Grappelli has recently changed `grp-container` from an ID to a class: https://github.com/sehmaschine/django-grappelli/commit/9eaca21706d5ad900a215218d9708a85c550df62

So this brings django-polymorphic-tree in line with that change.